### PR TITLE
debug: pass failing unit test - Value errors from shape / num pixels mismatch

### DIFF
--- a/simSPI/transfer.py
+++ b/simSPI/transfer.py
@@ -22,8 +22,12 @@ def ctf_freqs(n_pixels, psize=1.0, dim=2):
 
     Returns
     -------
-    freq_1d : numpy.ndarray, shape (N//2,)
+    freq_1d : numpy.ndarray, shape (n_pixels//2,)
         Frequencies in 1D, with dc at left most.
+        1 D goes from 0 to n_pixels//2-1
+        e.g. n_pixels=6 goes from 0 1 2
+        n_pixels//2 - 1 = 3 -1 = 2
+        only the positive part is returned; we skip over the negative part -3 -2 -1.
     freq_mag_2d : numpy.ndarray, shape (N,N)
         Magnitude of 2D frequency vector, with -ve frequencies in left half,
         and dc and +ve frequencies in right half.

--- a/tests/test_multislice.py
+++ b/tests/test_multislice.py
@@ -9,11 +9,11 @@ from simSPI import multislice, transfer
 
 def test_exit_wave_to_image():
     """High dose, no ctf/dqe/ntf."""
-    N = 64
-    sphere = raster_geometry.sphere([N, N, N], radius=N // 8, position=0.25).astype(
-        np.float32
-    )
-    ones = np.ones((N, N))
+    num_pix = 64
+    sphere = raster_geometry.sphere(
+        [num_pix, num_pix, num_pix], radius=num_pix // 8, position=0.25
+    ).astype(np.float32)
+    ones = np.ones((num_pix, num_pix))
     exit_wave = sphere.sum(-1)
     exit_wave_f = fourier.do_fft(exit_wave, dim=2)
     high_dose = 1e9 * exit_wave.max()
@@ -27,24 +27,24 @@ def test_exit_wave_to_image():
         ntf=ones,
     )
 
-    assert i.shape == (N, N)
-    assert shot_noise_sample.shape == (N, N)
-    assert i0_dqe.shape == (N, N)
-    assert i0.shape == (N, N)
+    assert i.shape == (num_pix, num_pix)
+    assert shot_noise_sample.shape == (num_pix, num_pix)
+    assert i0_dqe.shape == (num_pix, num_pix)
+    assert i0.shape == (num_pix, num_pix)
     assert np.allclose(i / high_dose, exit_wave, atol=1e-4)
 
 
 def test_apply_poisson_shot_noise_sample():
     """Poisson noise high vs low."""
-    N = 64
-    signal = np.ones((N, N))
+    num_pix = 64
+    signal = np.ones((num_pix, num_pix))
     # hi noise
     dose_hin = 0.1
     noise_bg_hin = 1
     shot_noise_sample_hin = multislice.apply_poisson_shot_noise_sample(
         signal=signal, dose=dose_hin, noise_bg=noise_bg_hin
     )
-    assert shot_noise_sample_hin.shape == (N, N)
+    assert shot_noise_sample_hin.shape == (num_pix, num_pix)
 
     # hi dose
     dose_hid = 1
@@ -64,37 +64,37 @@ def test_apply_poisson_shot_noise_sample():
 
 def test_apply_complex_ctf_to_exit_wave():
     """Test apply_complex_ctf_to_exit_wave."""
-    N_random = np.random.uniform(low=50, high=100)
-    N = int(2 * (N_random // 2))  # even N
-    assert np.isclose(N % 2, 0), "must be even for test to work"
+    num_random = np.random.uniform(low=50, high=100)
+    num_pix = int(2 * (num_random // 2))  # even N
+    assert np.isclose(num_pix % 2, 0), "must be even for test to work"
     i0 = multislice.apply_complex_ctf_to_exit_wave(
-        exit_wave_f=np.ones((N, N)), complex_ctf=np.ones((N, N))
+        exit_wave_f=np.ones((num_pix, num_pix)), complex_ctf=np.ones((num_pix, num_pix))
     )
-    assert i0.shape == (N, N)
+    assert i0.shape == (num_pix, num_pix)
 
 
 def test_apply_dqe():
     """Test apply_dqe."""
-    N_random = np.random.uniform(low=50, high=100)
-    N = int(2 * (N_random // 2))
-    assert np.isclose(N % 2, 0), "must be even for test to work"
-    ones = np.ones((N, N))
-    freq_A_2d = transfer.ctf_freqs(N, dim=2)[0]
+    num_random = np.random.uniform(low=50, high=100)
+    num_pix = int(2 * (num_random // 2))
+    assert np.isclose(num_pix % 2, 0), "must be even for test to work"
+    ones = np.ones((num_pix, num_pix))
+    freq_A_2d = transfer.ctf_freqs(num_pix, dim=2)[0]
     mtf_const = 1.5
     mtf2 = (np.sinc(freq_A_2d * mtf_const)) ** 2
     ntf2 = np.sinc(freq_A_2d) ** 2
     dqe = mtf2 / ntf2
     i0_dqe = multislice.apply_dqe(ones, dqe)
-    assert i0_dqe.shape == (N, N)
+    assert i0_dqe.shape == (num_pix, num_pix)
 
 
 def test_apply_ntf():
     """Test apply_ntf."""
-    N_random = np.random.uniform(low=50, high=100)
-    N = int(2 * (N_random // 2))
-    assert np.isclose(N % 2, 0), "must be even for test to work"
-    ones = np.ones((N, N))
-    freq_A_2d = transfer.ctf_freqs(N, dim=2)[0]
+    num_random = np.random.uniform(low=50, high=100)
+    num_pix = int(2 * (num_random // 2))
+    assert np.isclose(num_pix % 2, 0), "must be even for test to work"
+    ones = np.ones((num_pix, num_pix))
+    freq_A_2d = transfer.ctf_freqs(num_pix, dim=2)[0]
     ntf = np.sinc(freq_A_2d)
     i = multislice.apply_ntf(shot_noise_sample=ones, ntf=ntf)
-    assert i.shape == (N, N)
+    assert i.shape == (num_pix, num_pix)

--- a/tests/test_multislice.py
+++ b/tests/test_multislice.py
@@ -9,11 +9,11 @@ from simSPI import multislice, transfer
 
 def test_exit_wave_to_image():
     """High dose, no ctf/dqe/ntf."""
-    num_pix = 64
+    n_pixels = 64
     sphere = raster_geometry.sphere(
-        [num_pix, num_pix, num_pix], radius=num_pix // 8, position=0.25
+        [n_pixels, n_pixels, n_pixels], radius=n_pixels // 8, position=0.25
     ).astype(np.float32)
-    ones = np.ones((num_pix, num_pix))
+    ones = np.ones((n_pixels, n_pixels))
     exit_wave = sphere.sum(-1)
     exit_wave_f = fourier.do_fft(exit_wave, dim=2)
     high_dose = 1e9 * exit_wave.max()
@@ -27,24 +27,24 @@ def test_exit_wave_to_image():
         ntf=ones,
     )
 
-    assert i.shape == (num_pix, num_pix)
-    assert shot_noise_sample.shape == (num_pix, num_pix)
-    assert i0_dqe.shape == (num_pix, num_pix)
-    assert i0.shape == (num_pix, num_pix)
+    assert i.shape == (n_pixels, n_pixels)
+    assert shot_noise_sample.shape == (n_pixels, n_pixels)
+    assert i0_dqe.shape == (n_pixels, n_pixels)
+    assert i0.shape == (n_pixels, n_pixels)
     assert np.allclose(i / high_dose, exit_wave, atol=1e-4)
 
 
 def test_apply_poisson_shot_noise_sample():
     """Poisson noise high vs low."""
-    num_pix = 64
-    signal = np.ones((num_pix, num_pix))
+    n_pixels = 64
+    signal = np.ones((n_pixels, n_pixels))
     # hi noise
     dose_hin = 0.1
     noise_bg_hin = 1
     shot_noise_sample_hin = multislice.apply_poisson_shot_noise_sample(
         signal=signal, dose=dose_hin, noise_bg=noise_bg_hin
     )
-    assert shot_noise_sample_hin.shape == (num_pix, num_pix)
+    assert shot_noise_sample_hin.shape == (n_pixels, n_pixels)
 
     # hi dose
     dose_hid = 1
@@ -64,37 +64,38 @@ def test_apply_poisson_shot_noise_sample():
 
 def test_apply_complex_ctf_to_exit_wave():
     """Test apply_complex_ctf_to_exit_wave."""
-    num_random = np.random.uniform(low=50, high=100)
-    num_pix = int(2 * (num_random // 2))  # even N
-    assert np.isclose(num_pix % 2, 0), "must be even for test to work"
+    n_random = np.random.uniform(low=50, high=100)
+    n_pixels = int(2 * (n_random // 2))  # even N
+    assert np.isclose(n_pixels % 2, 0), "must be even for test to work"
     i0 = multislice.apply_complex_ctf_to_exit_wave(
-        exit_wave_f=np.ones((num_pix, num_pix)), complex_ctf=np.ones((num_pix, num_pix))
+        exit_wave_f=np.ones((n_pixels, n_pixels)),
+        complex_ctf=np.ones((n_pixels, n_pixels)),
     )
-    assert i0.shape == (num_pix, num_pix)
+    assert i0.shape == (n_pixels, n_pixels)
 
 
 def test_apply_dqe():
     """Test apply_dqe."""
-    num_random = np.random.uniform(low=50, high=100)
-    num_pix = int(2 * (num_random // 2))
-    assert np.isclose(num_pix % 2, 0), "must be even for test to work"
-    ones = np.ones((num_pix, num_pix))
-    freq_A_2d = transfer.ctf_freqs(num_pix, dim=2)[0]
+    n_random = np.random.uniform(low=50, high=100)
+    n_pixels = int(2 * (n_random // 2))
+    assert np.isclose(n_pixels % 2, 0), "must be even for test to work"
+    ones = np.ones((n_pixels, n_pixels))
+    freq_A_2d = transfer.ctf_freqs(n_pixels, dim=2)[0]
     mtf_const = 1.5
     mtf2 = (np.sinc(freq_A_2d * mtf_const)) ** 2
     ntf2 = np.sinc(freq_A_2d) ** 2
     dqe = mtf2 / ntf2
     i0_dqe = multislice.apply_dqe(ones, dqe)
-    assert i0_dqe.shape == (num_pix, num_pix)
+    assert i0_dqe.shape == (n_pixels, n_pixels)
 
 
 def test_apply_ntf():
     """Test apply_ntf."""
-    num_random = np.random.uniform(low=50, high=100)
-    num_pix = int(2 * (num_random // 2))
-    assert np.isclose(num_pix % 2, 0), "must be even for test to work"
-    ones = np.ones((num_pix, num_pix))
-    freq_A_2d = transfer.ctf_freqs(num_pix, dim=2)[0]
+    n_random = np.random.uniform(low=50, high=100)
+    n_pixels = int(2 * (n_random // 2))
+    assert np.isclose(n_pixels % 2, 0), "must be even for test to work"
+    ones = np.ones((n_pixels, n_pixels))
+    freq_A_2d = transfer.ctf_freqs(n_pixels, dim=2)[0]
     ntf = np.sinc(freq_A_2d)
     i = multislice.apply_ntf(shot_noise_sample=ones, ntf=ntf)
-    assert i.shape == (num_pix, num_pix)
+    assert i.shape == (n_pixels, n_pixels)

--- a/tests/test_multislice.py
+++ b/tests/test_multislice.py
@@ -66,6 +66,7 @@ def test_apply_complex_ctf_to_exit_wave():
     """Test apply_complex_ctf_to_exit_wave."""
     N_random = np.random.uniform(low=50, high=100)
     N = int(2 * (N_random // 2))  # even N
+    assert np.isclose(N % 2, 0), "must be even for test to work"
     i0 = multislice.apply_complex_ctf_to_exit_wave(
         exit_wave_f=np.ones((N, N)), complex_ctf=np.ones((N, N))
     )
@@ -76,6 +77,7 @@ def test_apply_dqe():
     """Test apply_dqe."""
     N_random = np.random.uniform(low=50, high=100)
     N = int(2 * (N_random // 2))
+    assert np.isclose(N % 2, 0), "must be even for test to work"
     ones = np.ones((N, N))
     freq_A_2d = transfer.ctf_freqs(N, dim=2)[0]
     mtf_const = 1.5
@@ -90,6 +92,7 @@ def test_apply_ntf():
     """Test apply_ntf."""
     N_random = np.random.uniform(low=50, high=100)
     N = int(2 * (N_random // 2))
+    assert np.isclose(N % 2, 0), "must be even for test to work"
     ones = np.ones((N, N))
     freq_A_2d = transfer.ctf_freqs(N, dim=2)[0]
     ntf = np.sinc(freq_A_2d)

--- a/tests/test_multislice.py
+++ b/tests/test_multislice.py
@@ -65,7 +65,7 @@ def test_apply_poisson_shot_noise_sample():
 def test_apply_complex_ctf_to_exit_wave():
     """Test apply_complex_ctf_to_exit_wave."""
     n_random = np.random.uniform(low=50, high=100)
-    n_pixels = int(2 * (n_random // 2))  # even N
+    n_pixels = int((n_random // 2) * 2)  # even N
     assert np.isclose(n_pixels % 2, 0), "must be even for test to work"
     i0 = multislice.apply_complex_ctf_to_exit_wave(
         exit_wave_f=np.ones((n_pixels, n_pixels)),

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -7,7 +7,7 @@ from simSPI import transfer
 
 def test_ctf_freqs():
     """Test for ctf_freq."""
-    n_pixels = int((np.random.randint(low=8, high=128) // 2) * 2)
+    n_pixels = int(2 * (np.random.randint(low=8, high=128) // 2))
     assert np.isclose(
         n_pixels % 2, 0
     ), "must be even for test to work. n_pixels {}".format(n_pixels)

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -12,7 +12,7 @@ def test_ctf_freqs():
         n_pixels % 2, 0
     ), "must be even for test to work. n_pixels {}".format(n_pixels)
     freq_1d = transfer.ctf_freqs(n_pixels, dim=1)
-    assert freq_1d.shape == (n_pixels // 2,)
+    assert freq_1d.shape == (n_pixels // 2 - 1,)
     assert np.isclose(freq_1d.min(), 0)
     assert np.isclose(freq_1d[0], 0)
     assert freq_1d[-1] < n_pixels // 2

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -56,7 +56,6 @@ def test_random_ctfs():
     assert np.isclose(
         n_pixels % 2, 0
     ), "must be even for test to work. n_pixels {}".format(n_pixels)
-    print(n_pixels)
     n_particles = np.random.randint(low=3, high=7)
     df_min = np.random.uniform(low=5000, high=30000)
     df_max = df_min + 100

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -7,14 +7,15 @@ from simSPI import transfer
 
 def test_ctf_freqs():
     """Test for ctf_freq."""
-    n_pixels = (np.random.randint(low=8, high=128) // 2) * 2
+    n_pixels = int((np.random.randint(low=8, high=128) // 2) * 2)
     assert np.isclose(
         n_pixels % 2, 0
     ), "must be even for test to work. n_pixels {}".format(n_pixels)
     freq_1d = transfer.ctf_freqs(n_pixels, dim=1)
-    assert freq_1d.shape == (n_pixels // 2 - 1,)
+    assert freq_1d.shape == (n_pixels // 2,)
     assert np.isclose(freq_1d.min(), 0)
     assert np.isclose(freq_1d[0], 0)
+    assert np.isclose(freq_1d.max(), n_pixels // 2 - 1)
     assert freq_1d[-1] < n_pixels // 2
     psize = np.random.uniform(low=1, high=10)
     freq_mag_2d, angles_rad = transfer.ctf_freqs(n_pixels, dim=2, psize=psize)

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -15,7 +15,6 @@ def test_ctf_freqs():
     assert freq_1d.shape == (n_pixels // 2,)
     assert np.isclose(freq_1d.min(), 0)
     assert np.isclose(freq_1d[0], 0)
-    assert np.isclose(freq_1d.max(), n_pixels // 2 - 1)
     assert freq_1d[-1] < n_pixels // 2
     psize = np.random.uniform(low=1, high=10)
     freq_mag_2d, angles_rad = transfer.ctf_freqs(n_pixels, dim=2, psize=psize)

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -8,6 +8,9 @@ from simSPI import transfer
 def test_ctf_freqs():
     """Test for ctf_freq."""
     n_pixels = (np.random.randint(low=8, high=128) // 2) * 2
+    assert np.isclose(
+        n_pixels % 2, 0
+    ), "must be even for test to work. n_pixels {}".format(n_pixels)
     freq_1d = transfer.ctf_freqs(n_pixels, dim=1)
     assert freq_1d.shape == (n_pixels // 2,)
     assert np.isclose(freq_1d.min(), 0)
@@ -24,6 +27,9 @@ def test_ctf_freqs():
 def test_eval_ctf():
     """Test for eval_ctf."""
     n_pixels = (np.random.randint(low=8, high=128) // 2) * 2
+    assert np.isclose(
+        n_pixels % 2, 0
+    ), "must be even for test to work. n_pixels {}".format(n_pixels)
     freq_mag_2d, angles_rad = transfer.ctf_freqs(n_pixels, dim=2)
     ac = np.random.uniform(low=0.07, high=0.1)
     ctf = transfer.eval_ctf(
@@ -47,6 +53,10 @@ def test_eval_ctf():
 def test_random_ctfs():
     """Test for random_ctfs."""
     n_pixels = (np.random.randint(low=8, high=128) // 2) * 2
+    assert np.isclose(
+        n_pixels % 2, 0
+    ), "must be even for test to work. n_pixels {}".format(n_pixels)
+    print(n_pixels)
     n_particles = np.random.randint(low=3, high=7)
     df_min = np.random.uniform(low=5000, high=30000)
     df_max = df_min + 100


### PR DESCRIPTION
Can't reproduce failing unit test yet. Python 8 issue?

https://github.com/compSPI/simSPI/runs/4031149125?check_suite_focus=true

```
Run $CONDA/bin/pytest --cov-report term --cov-report xml:coverage.xml --cov=simSPI tests
  $CONDA/bin/pytest --cov-report term --cov-report xml:coverage.xml --cov=simSPI tests
  shell: /bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.12/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.12/x64/lib
============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /home/runner/work/simSPI/simSPI, configfile: pytest.ini, testpaths: tests
plugins: cov-3.0.0
collected 8 items

tests/test_multislice.py ...F.                                           [ 62%]
tests/test_transfer.py ...                                               [100%]

=================================== FAILURES ===================================
________________________________ test_apply_dqe ________________________________

    def test_apply_dqe():
        """Test apply_dqe."""
        N_random = np.random.uniform(low=50, high=100)
        N = int(2 * (N_random // 2))
        ones = np.ones((N, N))
        freq_A_2d = transfer.ctf_freqs(N, dim=2)[0]
        mtf_const = 1.5
        mtf2 = (np.sinc(freq_A_2d * mtf_const)) ** 2
        ntf2 = np.sinc(freq_A_2d) ** 2
        dqe = mtf2 / ntf2
>       i0_dqe = multislice.apply_dqe(ones, dqe)

tests/test_multislice.py:85: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

i0_f = array([[1., 1., 1., ..., 1., 1., 1.],
       [1., 1., 1., ..., 1., 1., 1.],
       [1., 1., 1., ..., 1., 1., 1.],
       ...,
       [1., 1., 1., ..., 1., 1., 1.],
       [1., 1., 1., ..., 1., 1., 1.],
       [1., 1., 1., ..., 1., 1., 1.]])
dqe = array([[0.02518659, 0.01654163, 0.00994395, ..., 0.00994395, 0.01654163,
        0.02518659],
       [0.01654163, 0.00...16,
        0.01654163],
       [0.02518659, 0.01654163, 0.00994395, ..., 0.00994395, 0.01654163,
        0.02518659]])

    def apply_dqe(i0_f, dqe):
        """Convolution with detector's DQE.
    
        Convolution of (ctf applied) exit wave
        with sqrt of the detective quantum efficiency.
    
        Parameters
        ----------
        i0_f : numpy.ndarray, shape (N,N)
            Image with ctf applied.
        dqe : numpy.ndarray, shape (N,N)
            Detective quantum efficiency (in 2D).
    
        Returns
        -------
        i0_dqe : numpy.ndarray, shape (N,N)
            Exit wave with dqe applied (in real space).
        """
>       i0_dqe = fourier.do_ifft(i0_f * np.sqrt(dqe), dim=2)
E       ValueError: operands could not be broadcast together with shapes (98,98) (99,99)

simSPI/multislice.py:47: ValueError
=============================== warnings summary ===============================
../../../../../usr/share/miniconda/lib/python3.9/site-packages/raster_geometry/raster.py:2447
  /usr/share/miniconda/lib/python3.9/site-packages/raster_geometry/raster.py:2447: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    dtype=np.float):

-- Docs: https://docs.pytest.org/en/stable/warnings.html

----------- coverage: platform linux, python 3.9.5-final-0 -----------
Name                   Stmts   Miss  Cover   Missing
----------------------------------------------------
simSPI/__init__.py         1      0   100%
simSPI/multislice.py      21      0   100%
simSPI/transfer.py        50      3    94%   90, 97, 167
----------------------------------------------------
TOTAL                     72      3    96%
Coverage XML written to file coverage.xml

Required test coverage of 90.0% reached. Total coverage: 95.83%
=========================== short test summary info ============================
FAILED tests/test_multislice.py::test_apply_dqe - ValueError: operands could ...
=================== 1 failed, 7 passed, 1 warning in 10.13s ====================
Error: Process completed with exit code 1.
```